### PR TITLE
ontology-1.0.owl: "referenceValue" repeated

### DIFF
--- a/source/ontology-1.0.owl
+++ b/source/ontology-1.0.owl
@@ -308,7 +308,7 @@
   </owl:ObjectProperty>
 
   <owl:ObjectProperty rdf:about="&wikibase;referenceValueNormalized">
-      <rdfs:label>referenceValue</rdfs:label>
+      <rdfs:label>referenceValueNormalized</rdfs:label>
       <rdfs:comment>Link between Wikibase Property and reference normalized value predicate.</rdfs:comment>
       <rdfs:domain rdf:resource="&wikibase;Property"/>
   </owl:ObjectProperty>


### PR DESCRIPTION
The rdfs:label "referenceValue" is repeated. The second one should be "referenceValueNormalized". See <https://phabricator.wikimedia.org/T263867>.