### PR TITLE
Update wikibase-codesniffer to v1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"jakub-onderka/php-parallel-lint": "0.9.2",
 		"jakub-onderka/php-console-highlighter": "0.3.2",
 		"phpunit/phpunit": "~8.0",
-		"wikibase/wikibase-codesniffer": "^0.1.0"
+		"wikibase/wikibase-codesniffer": "^1.2.0"
 	},
 	"config": {
 		"component-dir": "source/components"

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -7,8 +7,6 @@ use PHPUnit\Framework\TestCase;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SmokeTest extends TestCase {
-	// Ignoring CS Warnings for the @covers rule as this file does not cover any php classes
-	// phpcs:disable MediaWiki.Commenting.MissingCovers.MissingCovers
 	private static $PAGE_PATH;
 
 	public static function setUpBeforeClass() : void {
@@ -19,6 +17,9 @@ class SmokeTest extends TestCase {
 		// phpcs:enable MediaWiki.Usage.ForbiddenFunctions.exec
 	}
 
+	/**
+	 * @coversNothing
+	 */
 	public function testMainPageContainsIntroText() {
 		$this->assertPageContains(
 			'Wikibase is an open-source software suite for creating',
@@ -26,6 +27,9 @@ class SmokeTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @coversNothing
+	 */
 	public function testLibrariesPageContainsLibraries() {
 		$this->assertPageContains(
 			'Libraries',
@@ -33,6 +37,9 @@ class SmokeTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @coversNothing
+	 */
 	public function testBootstrapCssIsWhereExpected() {
 		$this->assertRelativeFileExists( 'components/bootstrap/dist/css/bootstrap.min.css' );
 	}

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -3,7 +3,7 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * @licence GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SmokeTest extends TestCase {

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -7,12 +7,16 @@ use PHPUnit\Framework\TestCase;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SmokeTest extends TestCase {
-
+	// Ignoring CS Warnings for the @covers rule as this file does not cover any php classes
+	// phpcs:disable MediaWiki.Commenting.MissingCovers.MissingCovers
 	private static $PAGE_PATH;
 
 	public static function setUpBeforeClass() : void {
 		self::$PAGE_PATH = __DIR__ . '/../output_test/';
+		// In this particular case exec is needed to generate the static site output
+		// phpcs:disable MediaWiki.Usage.ForbiddenFunctions.exec
 		exec( 'composer build-test' );
+		// phpcs:enable MediaWiki.Usage.ForbiddenFunctions.exec
 	}
 
 	public function testMainPageContainsIntroText() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-require_once ( __DIR__ . '/../vendor/autoload.php' );
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Updates the wikibase codesniffer package to the latest version and auto-fixes some issue. I wasn't really sure about this `SmokeTest.php` file as it doesn't really tests anything besides particular parts of the content (which seems a little brittle to me). Let me know if this file is still relevant, otherwise I will just remove it.

Issue: [T264876](https://phabricator.wikimedia.org/T264876)